### PR TITLE
Add formal validation against the DDLm reference dictionary 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,23 +12,50 @@ apt-get -y install cod-tools
 
 apt-get -y install moreutils
 
-# run the checks
-# any output from cif_ddlm_dic_check flags
-# a problem, the grep for ":" just makes
-# sure that all lines are output.
+# install 'git' since it is needed to retrieve the imported dictionaries
 
+apt-get -y install git
+
+# Prepare dictionaries and template files that may be
+# required to properly validate other dictionaries
+TMP_DIR=$(mktemp -d)
+
+# Prepare the DDLm reference dictionary and the CIF_CORE dictionary.
+#
+# If these dictionaries are part of the checked GitHub repository,
+# then the local copies should be used to ensure self-consistency,
+# e.g. the latest version of the reference dictionary should validate
+# against itself. This scenario will most likely only occur in the
+# COMCIFS/cif_core repository. 
+#
+# If these dictionaries are not part of the checked GitHub repository,
+# then the latest available version from the COMCIFS/cif_core repository
+# should be retrieved.
+
+DDLM_REFERENCE_DIC=./ddl.dic
+if [ ! -f "${DDLM_REFERENCE_DIC}" ]
+then
+    git clone https://github.com/COMCIFS/cif_core.git "${TMP_DIR}"/cif_core
+    DDLM_REFERENCE_DIC="${TMP_DIR}"/cif_core/ddl.dic
+    # Specify the location of imported files (i.e. "templ_attr.cif")
+    COD_TOOLS_DDLM_IMPORT_PATH="${TMP_DIR}"/cif_core
+fi
+export COD_TOOLS_DDLM_IMPORT_PATH 
+
+# run the checks
 shopt -s nullglob
-OUT_FILE=$(mktemp)
-ERR_FILE=$(mktemp)
+
+# Check dictionaries for stylistic and semantic issues
+OUT_FILE="${TMP_DIR}/cif_ddlm_dic_check.out"
+ERR_FILE="${TMP_DIR}/cif_ddlm_dic_check.err"
 for file in ./*.dic
 do
-    echo "$file"
     # Run the checks and report fatal errors
     cif_ddlm_dic_check "$file" > "${OUT_FILE}" 2> "${ERR_FILE}" || (
         echo "Execution of the 'cif_ddlm_dic_check' script failed with" \
              "the following errors:"
         cat "${ERR_FILE}"
-        rm -rf "${OUT_FILE}" "${ERR_FILE}"
+        rm -rf "${TMP_DIR}"
         exit 1
     )
 
@@ -52,9 +79,46 @@ do
     then
         echo "Dictionary check detected the following irregularities:";
         cat "${OUT_FILE}"
-        rm -rf "${OUT_FILE}" "${ERR_FILE}"
+        rm -rf "${TMP_DIR}"
         exit 1
     fi
 done
 
-rm -rf "${OUT_FILE}" "${ERR_FILE}"
+# Validate dictionaries against the DDLm reference dictionary
+OUT_FILE="${TMP_DIR}/ddlm_validate.out"
+ERR_FILE="${TMP_DIR}/ddlm_validate.err"
+for file in ./*.dic
+do
+    ddlm_validate --dictionaries "${DDLM_REFERENCE_DIC}" \
+        "$file" > "${OUT_FILE}" 2> "${ERR_FILE}" || (
+        echo "Execution of the 'ddlm_validate' script failed with" \
+             "the following errors:"
+        cat "${ERR_FILE}"
+        rm -rf "${TMP_DIR}"
+        exit 1
+    )
+
+    # Filter and report error messages
+    #~ grep "${ERR_FILE}" -v \
+    #~      -e "ignored message A" \
+    #~      -e "ignored message B" |
+    #~ sponge "${ERR_FILE}"
+    if [ -s "${ERR_FILE}" ]
+    then
+        echo "Dictionary validation generated the following non-fatal errors:"
+        cat "${ERR_FILE}"
+    fi
+
+    # Filter and report output messages
+    grep "${OUT_FILE}" -P -v \
+         -e "is recommended in the .*? scope" |
+    sponge "${OUT_FILE}"
+    if [ -s "${OUT_FILE}" ]
+    then
+        echo "Dictionary validation detected the following validation issues:";
+        cat "${OUT_FILE}"
+        rm -rf "${TMP_DIR}"
+        exit 1
+    fi
+done
+rm -rf "${TMP_DIR}"


### PR DESCRIPTION
This PR adds dictionary validation against the DDLm reference dictionary using the 'ddlm_validate' program.

I have taken the liberty of suppressing the messages that report missing _recommended_ data items (as described in the DICTIONARY_VALID loop), since otherwise a wall of messages relating to the `_description.common` and `_definition.scope` data items is generated. It would be worthwhile to eventually address these issues, but I assume they are of a rather low priority right now. These messages can be reenabled by commenting out lines 113-115.

Note, that the updated action properly fails on this repository due to formal validation issues in the "test.dic" file (incorrect enumeration value). 