### PR TITLE
Exclude errors involving _description_example.case

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,7 +111,8 @@ do
 
     # Filter and report output messages
     grep "${OUT_FILE}" -P -v \
-         -e "is recommended in the .*? scope" |
+         -e "is recommended in the .*? scope" \
+         -e "data item '_description_example.case' value" |
     sponge "${OUT_FILE}"
     if [ -s "${OUT_FILE}" ]
     then


### PR DESCRIPTION
This stops mismatches between example cases and expected types causing a failure.