### PR TITLE
Replaced grep option '-P' with '-E'

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -110,7 +110,7 @@ do
     fi
 
     # Filter and report output messages
-    grep "${OUT_FILE}" -P -v \
+    grep "${OUT_FILE}" -E -v \
          -e "is recommended in the .*? scope" \
          -e "data item '_description_example.case' value" |
     sponge "${OUT_FILE}"


### PR DESCRIPTION
It seems that I did not test PR #4 extensively enough before merging. The grep command with option '-P' only supports a single pattern, therefore the current error filtering will always fail. Furthermore, since the failure occurs in a pipe, the final exit status is still 0 and thus does not trigger the failure of the entire check action.

grep option '-E' does not seem to exhibit the same limitations.