### PR TITLE
Migrate to using 'cod-tools' from a fixed revision checkout.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ apt-get -y install git
 
 # Make a sparse check out a fixed 'cod-tools' revision
 COD_TOOLS_DIR=cod-tools
-COD_TOOLS_REV=8853
+COD_TOOLS_REV=8869
 mkdir ${COD_TOOLS_DIR}
 cd ${COD_TOOLS_DIR}
 svn co -r ${COD_TOOLS_REV} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ apt-get -y install git
 
 # Make a sparse check out a fixed 'cod-tools' revision
 COD_TOOLS_DIR=cod-tools
-COD_TOOLS_REV=8837
+COD_TOOLS_REV=8853
 mkdir ${COD_TOOLS_DIR}
 cd ${COD_TOOLS_DIR}
 svn co -r ${COD_TOOLS_REV} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ apt-get -y install git
 
 # Make a sparse check out a fixed 'cod-tools' revision
 COD_TOOLS_DIR=cod-tools
-COD_TOOLS_REV=8836
+COD_TOOLS_REV=8837
 mkdir ${COD_TOOLS_DIR}
 cd ${COD_TOOLS_DIR}
 svn co -r ${COD_TOOLS_REV} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,19 +2,49 @@
 
 set -ue
 
-# get latest cod-tools
-
 apt-get update
 
-apt-get -y install cod-tools
+# Install 'subversion' since it is needed to retrieve the cod-tools package
+apt-get -y install subversion
 
-# install 'moreutils' since it contain the 'sponge' program 
-
+# Install 'moreutils' since it contain the 'sponge' program 
 apt-get -y install moreutils
 
-# install 'git' since it is needed to retrieve the imported dictionaries
-
+# Install 'git' since it is needed to retrieve the imported dictionaries
 apt-get -y install git
+
+# Make a sparse check out a fixed 'cod-tools' revision
+COD_TOOLS_DIR=cod-tools
+COD_TOOLS_REV=8836
+mkdir ${COD_TOOLS_DIR}
+cd ${COD_TOOLS_DIR}
+svn co -r ${COD_TOOLS_REV} \
+       --depth immediates \
+       svn://www.crystallography.net/cod-tools/trunk .
+svn up -r ${COD_TOOLS_REV} \
+       --set-depth infinity \
+       dependencies makefiles scripts src
+
+# Install 'cod-tools' dependencies
+apt-get -y install sudo
+./dependencies/Ubuntu-20.04/build.sh
+./dependencies/Ubuntu-20.04/run.sh
+
+# Patch the Makefile and run custom build commands
+# to avoid time-intensive tests
+perl -pi -e 's/^(include \${DIFF_DEPEND})$/#$1/' \
+    makefiles/Makefile-perl-multiscript-tests
+make "$(pwd)"/src/lib/perl5/COD/CIF/Parser/Bison.pm
+make "$(pwd)"/src/lib/perl5/COD/CIF/Parser/Yapp.pm
+make ./src/lib/perl5/COD/ToolsVersion.pm
+
+PERL5LIB=$(pwd)/src/lib/perl5${PERL5LIB:+:${PERL5LIB}}
+export PERL5LIB
+# shellcheck disable=SC2123
+PATH=$(pwd)/scripts${PATH:+:${PATH}}
+export PATH
+
+cd ..
 
 # Prepare dictionaries and template files that may be
 # required to properly validate other dictionaries


### PR DESCRIPTION
This PR enables using a fixed revision 'cod-tools checkout instead of the one available in Ubuntu repositories. This should speed up the deployment of bug fixes and new features that are introduced to the 'cod-tools' package. 

This PR also contains the following changes to the 'cod-tools' software:
- `ddlm_validate`:
    - Implemented proper handling of the `_dictionary_valid.scope` and `_dictionary_valid.option` attributes.
- `cif_ddlm_dic_check`:
     - Added a check that detects missing and potentially incorrectly added unit of measurement.
     - Added multiple checks related to the `DICTIONARY_AUDIT` loop.
     - Added a check that detects improper definition revision dates.
     - Added a check that detects measurand data items that do not have associated standard uncertainty (SU) data items. 
     - Added a check that detects data names that deviate from the IUCr naming convention of SU items.
     - Added a check that detects situations when the type dimension attribute is used with incompatible type containers. 