### PR TITLE
Update the cod-tools dependency from r8869 to r8928.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ apt-get -y install git
 
 # Make a sparse check out a fixed 'cod-tools' revision
 COD_TOOLS_DIR=cod-tools
-COD_TOOLS_REV=8869
+COD_TOOLS_REV=8928
 mkdir ${COD_TOOLS_DIR}
 cd ${COD_TOOLS_DIR}
 svn co -r ${COD_TOOLS_REV} \
@@ -67,7 +67,7 @@ if [ ! -f "${DDLM_REFERENCE_DIC}" ]
 then
     git clone https://github.com/COMCIFS/cif_core.git "${TMP_DIR}"/cif_core
     DDLM_REFERENCE_DIC="${TMP_DIR}"/cif_core/ddl.dic
-    # Specify the location of imported files (i.e. "templ_attr.cif")
+    # Specify the location of imported files (e.g. "templ_attr.cif")
     COD_TOOLS_DDLM_IMPORT_PATH="${TMP_DIR}"/cif_core
 fi
 export COD_TOOLS_DDLM_IMPORT_PATH 
@@ -119,7 +119,9 @@ OUT_FILE="${TMP_DIR}/ddlm_validate.out"
 ERR_FILE="${TMP_DIR}/ddlm_validate.err"
 for file in ./*.dic
 do
-    ddlm_validate --dictionaries "${DDLM_REFERENCE_DIC}" \
+    ddlm_validate \
+        --follow-iucr-style-guide \
+        --dictionaries "${DDLM_REFERENCE_DIC}" \
         "$file" > "${OUT_FILE}" 2> "${ERR_FILE}" || (
         echo "Execution of the 'ddlm_validate' script failed with" \
              "the following errors:"
@@ -129,9 +131,9 @@ do
     )
 
     # Filter and report error messages
-    #~ grep "${ERR_FILE}" -v \
+    #~ grep "${ERR_FILE}" -E -v \
     #~      -e "ignored message A" \
-    #~      -e "ignored message B" |
+    #~      -e "regular expression matching ignored message B .*?" |
     #~ sponge "${ERR_FILE}"
     if [ -s "${ERR_FILE}" ]
     then
@@ -140,10 +142,10 @@ do
     fi
 
     # Filter and report output messages
-    grep "${OUT_FILE}" -E -v \
-         -e "is recommended in the .*? scope" \
-         -e "data item '_description_example.case' value" |
-    sponge "${OUT_FILE}"
+    #~ grep "${OUT_FILE}" -E -v \
+    #~      -e "ignored message A" \
+    #~      -e "regular expression matching ignored message B .*?" |
+    #~ sponge "${OUT_FILE}"
     if [ -s "${OUT_FILE}" ]
     then
         echo "Dictionary validation detected the following validation issues:";


### PR DESCRIPTION
This PR updates the cod-tools dependency from r8869 to r8928.

Notable changes:
- Add a check that detects potential incompatibilities between the attributes of linked data items.
- Correct the handling of the `_description_example.case` attribute in regards to the standard uncertainty eligibility. This properly resolves issue #3.
- Implement the handling of the 'Word' content type.
- Update the handling of the 'Imag' and 'Complex' data types.
- Add the '--follow-iucr-style-guide' option that silences notes about missing recommended attributes if they fit the criteria defined in the IUCr DDLm dictionary style guide version 1.1.0, rule 3.1.6. Currently, this covers the `_definition.class` and `_definition.scope` attributes in data item definitions.

Other changes:
- Add a check that detects improper usage of the `_definition_replaced.by` attribute.
- Add a check that detects improper usage of the `_category_key.name` attribute.
- Add a check that detects improper usage of the `_definition.class` attribute.
- Add a check that detects improper usage of the `_type.indices_referenced_id` attribute.
- Add a check that detects improper usage of the `_type.contents_referenced_id` attribute.
- Add a check that detects improper usage of the `_enumeration_default.value` attribute.
- Add a check that detects improper usage of the `_enumeration.def_index_id` attribute.
