### PR TITLE
Add the option to use additional dictionaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:bullseye
 
 COPY entrypoint.sh /entrypoint.sh
+COPY extra-dic-dir* /extra-dic-dir
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -ue
 
+TOP_EXTRA_DIC_DIR=extra-dic-dir
+
 apt-get update
 
 # Install 'subversion' since it is needed to retrieve the cod-tools package
@@ -70,7 +72,17 @@ then
     # Specify the location of imported files (e.g. "templ_attr.cif")
     COD_TOOLS_DDLM_IMPORT_PATH="${TMP_DIR}"/cif_core
 fi
-export COD_TOOLS_DDLM_IMPORT_PATH 
+
+# Add extra dictionaries to the import path.
+if [ -d "${TOP_EXTRA_DIC_DIR}" ]
+then
+    for EXTRA_DIC_DIR in "${TOP_EXTRA_DIC_DIR}"/*
+    do
+        COD_TOOLS_DDLM_IMPORT_PATH="${COD_TOOLS_DDLM_IMPORT_PATH}:${EXTRA_DIC_DIR}"
+    done
+fi
+
+export COD_TOOLS_DDLM_IMPORT_PATH
 
 # run the checks
 shopt -s nullglob


### PR DESCRIPTION
Closes #12.

This PR updates the dictionary check action to optionally use additional dictionaries in the checks.

There are a few points of discussion that might be worth addressing before merging the changes:
- For backward compatibility, the newest version of CIF_CORE repository will still be checked out inside the docker image if the DDLm reference dictionary cannot be located neither in the checked repository nor among the external dictionary repositories. This fallback might be a bit of an overkill, but it is needed since we did not use a pinned version of this repository in our checks. I suggest that we update the workflows of our existing dictionary repositories little-by-little and then remove this fallback code.
- The job expects that the extra dictionaries (if any) should be copied to the Docker image from the `cif-dictionaries` directory. Is this what was meant in #12 by "ordinary CI directories"?

I have testes this on my forks of CIF_CORE and Powder dictionary, seems to work as expected.

@jamesrhester is this what you had in mind?