### PR TITLE
Indices go to 9 for excluded errors and include twin_refln

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,8 +135,8 @@ do
          `# These evaluation methods should be allowed since they do not perform ` \
          `# calculations, but only transform data structures.` \
          `# See https://github.com/COMCIFS/cif_core/pull/561` \
-         -e "save_(reflns|diffrn_reflns)[.]limit_index_m_[1-8]_(min|max): .+ not contain evaluation" \
-         -e "save_(refln|diffrn_refln|diffrn_standard_refln|exptl_crystal_face)[.]index_m_[1-8]: .+ not contain evaluation" \
+         -e "save_(reflns|diffrn_reflns)[.]limit_index_m_[1-9]_(min|max): .+ not contain evaluation" \
+         -e "save_(refln|diffrn_refln|diffrn_standard_refln|exptl_crystal_face|twin_refln)[.]index_m_[1-9]: .+ not contain evaluation" \
     | sponge "${OUT_FILE}"
     if [ -s "${OUT_FILE}" ]
     then


### PR DESCRIPTION
The exclusions for the MS dictionary didn't encompass the full number of reflection indices, or include twin_refln. See [this recent run](https://github.com/jamesrhester/Modulated_Structures/actions/runs/18859050814/job/53813466875) for an example.