### PR TITLE
Update the checkout action from version 2 to version 6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: one_dict_semantics
         uses: ./
         id: dictionary_check_action


### PR DESCRIPTION
GitHub is deprecating Node 20 on GitHub Actions runners [1] therefore some actions will need to be migrated to newer versions.

[1] https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/